### PR TITLE
Fixed mergeAdditionalProperties from mutating the definition

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -249,7 +249,7 @@ function derefSchema (schema, options, state) {
           }
           if (options.mergeAdditionalProperties) {
             delete node.$ref
-            newValue = _.merge(newValue, node)
+            newValue = _.merge({}, newValue, node)
           }
           this.update(newValue)
           if (state.missing.indexOf(refVal) !== -1) {

--- a/test/index.js
+++ b/test/index.js
@@ -403,5 +403,17 @@ describe('json-schema-deref-sync', function () {
       expect(schema).to.be.ok
       expect(schema).to.deep.equal(expected)
     })
+
+    it('should merge properties without mutating the definition', function () {
+      var input = require('./schemas/mergeproperties.json')
+      var expected = require('./schemas/mergeproperties.expected.json')
+      var schema = deref(input, {
+        mergeAdditionalProperties: true,
+        removeIds: true,
+        baseFolder: './test/schemas'
+      })
+      expect(schema).to.be.ok
+      expect(schema).to.deep.equal(expected)
+    })
   })
 })

--- a/test/schemas/mergeproperties.expected.json
+++ b/test/schemas/mergeproperties.expected.json
@@ -1,0 +1,16 @@
+{
+  "description": "Just a basic schema.",
+  "title": "Merge Properties",
+  "type": "object",
+  "properties": {
+    "foo": {
+      "description": "bar property",
+      "type": "boolean",
+      "$id": "mergingProperties"
+    },
+    "bar": {
+      "type": "boolean",
+      "description": "Merging properties without mutating the defintiion"
+    }
+  }
+}

--- a/test/schemas/mergeproperties.json
+++ b/test/schemas/mergeproperties.json
@@ -1,0 +1,15 @@
+{
+  "description": "Just a basic schema.",
+  "title": "Merge Properties",
+  "type": "object",
+  "properties": {
+    "foo": {
+      "$ref": "bar.json",
+      "$id": "mergingProperties"
+    },
+    "bar": {
+      "$ref": "bar.json",
+      "description": "Merging properties without mutating the defintiion"
+    }
+  }
+}


### PR DESCRIPTION
Fixes #30

There is an issue where if you reference the same definition in multiple parts of a schema and use mergeAdditionalProperties, every instance of that definition will now be mutated to include any merged properties.

The expected behaviour would be that the additional properties would only be added to the schema for that one property not all reference of that definition.