### PR TITLE
Support the use of special chars in json pointers

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -81,7 +81,7 @@ function getRefPathValue (schema, refPath) {
   // the value for that key (ignoring empty keys)
   const keys = rpath.split('/').filter(k => !!k)
   return keys.reduce(function (value, key) {
-    return value[key]
+    return value[key.replace(/~1/g, '/').replace(/~0/, '~')]
   }, schema)
 }
 exports.getRefPathValue = getRefPathValue

--- a/test/index.js
+++ b/test/index.js
@@ -213,6 +213,15 @@ describe('json-schema-deref-sync', function () {
       expect(schema).to.deep.equal(expected)
     })
 
+    it('should work with deep links with special characters that represents slash', function () {
+      var input = require('./schemas/apideeplink-with-special-chars.json')
+      var expected = require('./schemas/apideeplink-with-special-chars.expected.json')
+
+      var schema = deref(input, { baseFolder: './test/schemas' })
+      expect(schema).to.be.ok
+      expect(schema).to.deep.equal(expected)
+    })
+
     it('should work with deep nested ref links', function () {
       var input = require('./schemas/apinestedrefs.json')
       var expected = require('./schemas/apinestedrefs.expected.json')

--- a/test/schemas/apideeplink-with-special-chars.expected.json
+++ b/test/schemas/apideeplink-with-special-chars.expected.json
@@ -1,0 +1,47 @@
+[
+  {
+    "description": "Remove a widget",
+    "href": "/widgets/{widgetId}",
+    "method": "DELETE",
+    "rel": "delete",
+    "title": "Delete"
+  },
+  {
+    "description": "Update a widget.",
+    "href": "/widgets/{widgetId}",
+    "method": "POST",
+    "rel": "update",
+    "title": "update",
+    "schema": {
+      "properties": {
+        "foo-id": {
+          "description": "Unique identifier.",
+          "readOnly": true,
+          "format": "uuid",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "type": "string",
+          "minLength": 1
+        },
+        "email": {
+          "description": "Email",
+          "format": "email",
+          "readOnly": false,
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "required": [
+        "fooId",
+        "email"
+      ],
+      "type": "object"
+    }
+  },
+  {
+    "description": "Invite account user to an account.",
+    "href": "/invite/account/:accountId",
+    "method": "POST",
+    "rel": "parent-action",
+    "title": "invite-account-user"
+  }
+]

--- a/test/schemas/apideeplink-with-special-chars.json
+++ b/test/schemas/apideeplink-with-special-chars.json
@@ -1,0 +1,38 @@
+[
+  {
+    "description": "Remove a widget",
+    "href": "/widgets/{widgetId}",
+    "method": "DELETE",
+    "rel": "delete",
+    "title": "Delete"
+  },
+  {
+    "description": "Update a widget.",
+    "href": "/widgets/{widgetId}",
+    "method": "POST",
+    "rel": "update",
+    "title": "update",
+    "schema": {
+      "properties": {
+        "foo-id": {
+          "$ref": "widget-update.json#/properties/foo~1bar~1id"
+        },
+        "email": {
+          "$ref": "widget-update.json#/properties/email~0address"
+        }
+      },
+      "required": [
+        "fooId",
+        "email"
+      ],
+      "type": "object"
+    }
+  },
+  {
+    "description": "Invite account user to an account.",
+    "href": "/invite/account/:accountId",
+    "method": "POST",
+    "rel": "parent-action",
+    "title": "invite-account-user"
+  }
+]

--- a/test/schemas/widget-update.json
+++ b/test/schemas/widget-update.json
@@ -6,6 +6,12 @@
     "foo-id": {
       "$ref": "foomodel.json#/definitions/id"
     },
+    "foo/bar/id": {
+      "$ref": "foomodel.json#/definitions/id"
+    },
+    "email~address": {
+      "$ref": "common-definitions.json#/definitions/email"
+    },
     "email": {
       "$ref": "common-definitions.json#/definitions/email"
     }


### PR DESCRIPTION
Based on spec https://tools.ietf.org/html/draft-ietf-appsawg-json-pointer-04

You should be able to use ~1 for slash, which we need due to the way we
split api swagger files.

So I hope we can add support for it.