### PR TITLE
Fix a typo in deref function documentation

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -276,7 +276,7 @@ function derefSchema (schema, options, state) {
  *                                    If set to <code>true</code> they will be removed. Merged properties will not get removed.
  *                                    Default: <code>false</code>.
  * @param {Object} options.loaders - A hash mapping reference types (e.g., 'file') to loader functions.
- * @return {Object|Error} the deref schema oran instance of <code>Error</code> if error.
+ * @return {Object|Error} the deref schema or an instance of <code>Error</code> if error.
  */
 function deref (schema, options) {
   options = _.defaults(options, defaults)


### PR DESCRIPTION
A space is missing between the words `or` and `an` resulting in the typo `...deref schema oran instance of...`