### PR TITLE
fix: don't re-walk an already-dereferenced $ref target

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -251,7 +251,17 @@ function derefSchema (schema, options, state) {
             delete node.$ref
             newValue = _.merge({}, newValue, node)
           }
-          this.update(newValue)
+          // Only walk into a resolved value the first time it is substituted.
+          // The same object is reused at every site pointing at that ref, so
+          // re-walking it repeats work already done - and when refs nest, each
+          // level is re-walked once per path that reaches it, which is
+          // exponential in the number of definitions.
+          const alreadyResolved =
+            newValue !== null && typeof newValue === 'object' && state.resolved.has(newValue)
+          if (newValue !== null && typeof newValue === 'object') {
+            state.resolved.add(newValue)
+          }
+          this.update(newValue, alreadyResolved)
           if (state.missing.indexOf(refVal) !== -1) {
             state.missing.splice(state.missing.indexOf(refVal), 1)
           }
@@ -293,7 +303,11 @@ function deref (schema, options) {
     circularRefs: [],
     cwd: cwd,
     missing: [],
-    history: []
+    history: [],
+    // Values already dereferenced during this call. A resolved ref is shared -
+    // the same object is substituted at every site that points at it - so once
+    // one has been walked there is nothing left to do on later substitutions.
+    resolved: new WeakSet()
   }
 
   try {


### PR DESCRIPTION
### Summary

When a `$ref` is replaced, `this.update(newValue)` lets `traverse` descend into the
substituted value:

```js
this.update(newValue)
```

The same resolved object is substituted at **every** site pointing at that ref, so
its subtree is walked again on each substitution. When refs nest, every level gets
re-walked once per path that reaches it — a schema where each definition references
the one below it twice is a DAG of *n* definitions but is traversed as **2ⁿ** nodes.

`deref()` is synchronous, so this blocks the event loop:

| definitions | input | before | after |
|---|---|---|---|
| 10 | 1.1 KB | 13.5 ms | 4.1 ms |
| 18 | 1.9 KB | 579.6 ms | 0.8 ms |
| 22 | 2.3 KB | 9,556 ms | 1.5 ms |
| **24** | **2.6 KB** | **38,250 ms** | **2.8 ms** |

A ~2.6 KB schema was enough to occupy a core for 38 seconds. The module's existing
cache only covers `refType === 'file'` loads, so internal `#/definitions/...` refs
were re-resolved every time.

### Fix

Track which resolved values have already been walked, and skip descending into one
that has been seen before (`this.update(newValue, true)`).

This is safe because resolved refs are **already shared** — substituting
`#/definitions/d` at two sites yields the same object today
(`result.properties.a === result.properties.b` is `true` on the current release), so
once it has been dereferenced there is nothing left to do on the next substitution.

### Verification

- Existing test suite passes: **41/41**.
- Output is **byte-for-byte identical** to the current implementation across **400**
  generated schemas covering nested refs, refs shared between several properties,
  repeated refs, and missing refs (`failOnMissing` paths).
- The pathological case is now flat: 40 levels resolves in ~1 ms, where 24 levels
  previously took 38 s.

### Notes

Circular refs are unaffected — that path (`checkLocalCircular` / the `history`
check) is untouched and its tests still pass.

Found and fixed with AI assistance (Claude). Happy to add a regression test that
asserts a deep shared-ref schema resolves in bounded time.
